### PR TITLE
Edit Bottom Nav Item Indicator color

### DIFF
--- a/presentation/src/main/res/layout/activity_main.xml
+++ b/presentation/src/main/res/layout/activity_main.xml
@@ -34,7 +34,7 @@
             android:layout_width="match_parent"
             android:layout_height="63dp"
             android:background="@color/white"
-            app:itemBackground="@color/white"
+            app:itemActiveIndicatorStyle="@color/white"
             app:itemIconTint="@drawable/menu_item_color"
             app:layout_constraintBottom_toBottomOf="parent"
             app:labelVisibilityMode="unlabeled"


### PR DESCRIPTION
바텀네비게이션의 선택된 아이템의 배경색상이 보라색인 문제를 해결하였습니다.